### PR TITLE
clone project

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -13,6 +13,7 @@ import pushCommand from "@/subcommands/push/mod.ts";
 import dbCommand from "@/subcommands/db/mod.ts";
 import commitCommand from "@/subcommands/commit/mod.ts";
 import deployCommand from "@/subcommands/deploy/mod.ts";
+import cloneCommand from "@/subcommands/clone/mod.ts";
 
 const DEFAULT_LOG_LEVEL = "INFO";
 const { logLevel = DEFAULT_LOG_LEVEL } = await getConfig().get();
@@ -32,4 +33,5 @@ await new Command()
   .command("db", dbCommand)
   .command("commit", commitCommand)
   .command("deploy", deployCommand)
+  .command("clone", cloneCommand)
   .parse(Deno.args);

--- a/src/api/jet.ts
+++ b/src/api/jet.ts
@@ -1,6 +1,7 @@
 import { getConfig } from "@/api/mod.ts";
 
 import {
+  cloneProject as doCloneProject,
   commit as doCommit,
   configurationHash as doConfigurationHash,
   createFunction as doCreateFunction,
@@ -23,7 +24,7 @@ import {
   updateMigration as doUpdateMigration,
 } from "@/api/jet/mod.ts";
 
-import { ProjectPatch } from "@/jcli/config/project-json.ts";
+import { ProjectDotJSON, ProjectPatch } from "@/jcli/config/project-json.ts";
 import { JcliConfigDotJSON } from "@/jcli/config/jcli-config-json.ts";
 import { getLogger } from "@/jcli/logger.ts";
 import { Project } from "@/jet/project.ts";
@@ -137,6 +138,25 @@ export interface ListEnvironmentVariablesArgs {
   environmentName: "DEVELOPMENT" | "PRODUCTION";
 }
 
+export interface CloneProjectArgs {
+  projectId: string;
+}
+
+export interface JetProject {
+  name: string;
+  configuration: ProjectDotJSON;
+  functions: AsyncIterable<{
+    name: string;
+    files: ReadonlyArray<{ path: string; hash: string; code: string }>;
+  }>;
+  migrations: AsyncIterable<{
+    version: number;
+    name: string | null;
+    hash: string;
+    content: string;
+  }>;
+}
+
 export interface Jet {
   createProject(args: CreateProjectArgs): Promise<Project>;
   updateConfiguration(args: UpdateConfigurationArgs): Promise<void>;
@@ -160,6 +180,7 @@ export interface Jet {
   listEnvironmentVariables(
     args: ListEnvironmentVariablesArgs,
   ): Promise<Array<{ name: string; value: string }>>;
+  cloneProject(args: CloneProjectArgs): Promise<JetProject>;
 }
 
 function logDebugMetricsWrapper<T, U>(
@@ -250,5 +271,9 @@ export const jet: Jet = {
   listEnvironmentVariables: logDebugMetricsWrapper(
     doListEnvironmentVariables,
     "list environment variables",
+  ),
+  cloneProject: logDebugMetricsWrapper(
+    doCloneProject,
+    "clone a Jet project",
   ),
 };

--- a/src/api/jet/queries/clone.ts
+++ b/src/api/jet/queries/clone.ts
@@ -1,0 +1,124 @@
+const projectQuery = `
+query Project(
+  $projectNodeId: ID!
+) {
+  node(nodeId: $projectNodeId) {
+    ... on ProjectsProject {
+      name
+      draftConfiguration
+    }
+  }
+}
+`;
+
+const listDraftMigrationsQuery = `
+  query ListDraftMigrations(
+    $projectNodeId: ID!
+    $first: Int!
+    $after: String
+  ) {
+    node(nodeId: $projectNodeId) {
+      ... on ProjectsProject {
+        draftMigrations(first: $first, after: $after) {
+          pageInfo {
+            endCursor
+            hasNextPage
+          }
+
+          nodes {
+            ... on DatabaseDraftMigration {
+              version
+              name
+              hash
+              content
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const listDraftFunctionsQuery = `
+  query ListDraftFunctions(
+    $projectNodeId: ID!
+    $first: Int!
+    $after: String
+  ) {
+    node(nodeId: $projectNodeId) {
+      ... on ProjectsProject {
+        draftFunctions(first: $first, after: $after) {
+          pageInfo {
+            endCursor
+            hasNextPage
+          }
+
+          nodes {
+            ... on LambdaDraftFunction {
+              name
+              files {
+                path
+                hash
+                settings {
+                  code
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+interface ProjectQueryResponse {
+  node: {
+    name: string;
+    draftConfiguration: string;
+  };
+}
+
+interface ListDraftMigrationsQueryResponse {
+  node: {
+    draftMigrations: {
+      pageInfo: {
+        endCursor: string;
+        hasNextPage: boolean;
+      };
+      nodes: ReadonlyArray<{
+        version: number;
+        name: string;
+        hash: string;
+        content: string;
+      }>;
+    };
+  };
+}
+
+interface ListDraftFunctionsQueryResponse {
+  node: {
+    draftFunctions: {
+      pageInfo: {
+        endCursor: string;
+        hasNextPage: boolean;
+      };
+      nodes: ReadonlyArray<{
+        name: string;
+        files: ReadonlyArray<{
+          path: string;
+          hash: string;
+          settings: {
+            code: string;
+          };
+        }>;
+      }>;
+    };
+  };
+}
+
+export { listDraftFunctionsQuery, listDraftMigrationsQuery, projectQuery };
+export type {
+  ListDraftFunctionsQueryResponse,
+  ListDraftMigrationsQueryResponse,
+  ProjectQueryResponse,
+};

--- a/src/api/jet/queries/configuration-hash.ts
+++ b/src/api/jet/queries/configuration-hash.ts
@@ -1,5 +1,5 @@
 export const configurationHashQuery = `
-  query projectsConfigurationHash($configuration: String!) {
+  query projectsConfigurationHash($configuration: ObjectJSON!) {
     projectsConfigurationHash(configuration: $configuration)
   }
 `;

--- a/src/api/mod.ts
+++ b/src/api/mod.ts
@@ -1,7 +1,7 @@
 import { Console, consoleImpl } from "@/api/console.ts";
 import { DB, db, DBClass } from "@/api/db.ts";
 import { DirEntry, FS, fs, MkdirOptions, WriteFileOptions } from "@/api/fs.ts";
-import { Jet, jet } from "@/api/jet.ts";
+import { Jet, jet, JetProject } from "@/api/jet.ts";
 
 import { Config } from "@/jcli/config/config.ts";
 import {
@@ -28,6 +28,7 @@ export type {
   DirEntry,
   FS,
   Jet,
+  JetProject,
   MkdirOptions,
   WriteFileOptions,
 };

--- a/src/jcli/config/project-json.ts
+++ b/src/jcli/config/project-json.ts
@@ -22,8 +22,8 @@ export function projectDotJSONPath(projectName?: string): string {
 }
 
 export class ProjectDotJSON {
-  #name: string;
-  #title: string;
+  readonly name: string;
+  readonly title: string;
   #capabilities: Array<ProjectCapability>;
   #instances: Array<ProjectPluginInstance>;
 
@@ -32,16 +32,16 @@ export class ProjectDotJSON {
   }
 
   constructor(project: Project) {
-    this.#name = project.name;
-    this.#title = project.title;
+    this.name = project.name;
+    this.title = project.title;
     this.#capabilities = project.capabilities;
     this.#instances = project.instances;
   }
 
   toJSON() {
     return {
-      name: this.#name,
-      title: this.#title,
+      name: this.name,
+      title: this.title,
       capabilities: this.#capabilities,
       instances: this.#instances,
     };

--- a/src/jcli/file/functions-man.ts
+++ b/src/jcli/file/functions-man.ts
@@ -9,6 +9,8 @@ import {
   listFilesRec,
   zipFiles,
 } from "@/jcli/file/files-man.ts";
+import { digest } from "@/jcli/crypto.ts";
+
 import { PreparedQuery } from "sqlite";
 
 const BASE_PATH = "./functions";
@@ -32,6 +34,18 @@ export function FunctionFileEntry(functionName: string) {
     constructor(relativePath: string) {
       super(join(BASE_PATH, functionName, relativePath));
       this.serverPath = join("/", relativePath);
+    }
+
+    async digest() {
+      if (undefined === this._digest) {
+        const encoder = new TextEncoder();
+
+        this._digest = await digest(
+          encoder.encode(`${this.serverPath}${await this.content()}`),
+        );
+      }
+
+      return this._digest;
     }
 
     setDigest(digest: string) {

--- a/src/jcli/file/functions-man.ts
+++ b/src/jcli/file/functions-man.ts
@@ -112,15 +112,17 @@ async function* diffFunctionFiles<
   FileEntryConstructor: new (path: string) => T,
 ): AsyncIterable<FileChange<T>> {
   const functionFilesWas = new Map<string, T>(
-    listFunctionFileHashesQuery().map((
-      [path, hash],
-    ) => {
-      const entry = new FileEntryConstructor(
-        buildFunctionFileRelativePath(path, functionName),
-      );
-      entry.setDigest(hash);
-      return [path, entry];
-    }),
+    listFunctionFileHashesQuery()
+      .filter(([path]) => path.startsWith(`functions/${functionName}`))
+      .map((
+        [path, hash],
+      ) => {
+        const entry = new FileEntryConstructor(
+          buildFunctionFileRelativePath(path, functionName),
+        );
+        entry.setDigest(hash);
+        return [path, entry];
+      }),
   );
 
   for await (

--- a/src/jcli/file/migrations-man.ts
+++ b/src/jcli/file/migrations-man.ts
@@ -9,6 +9,8 @@ import {
   zipFiles,
 } from "@/jcli/file/files-man.ts";
 
+import { digest } from "@/jcli/crypto.ts";
+
 import { chunk } from "@/utility/async-iterable.ts";
 
 export const BASE_PATH = "./migrations";
@@ -30,6 +32,24 @@ export class MigrationFileEntry extends FileEntry {
 
   constructor(path: string) {
     super(path);
+  }
+
+  async digest(): Promise<string> {
+    if (undefined === this._digest) {
+      const encoder = new TextEncoder();
+
+      let subject: string;
+
+      if (this.name) {
+        subject = `${this.version}${this.name}${await this.content()}`;
+      } else {
+        subject = `${this.version}${await this.content()}`;
+      }
+
+      this._digest = await digest(encoder.encode(subject));
+    }
+
+    return this._digest;
   }
 
   async setDiff(entry: MigrationFileEntry): Promise<boolean> {

--- a/src/jcli/file/project.ts
+++ b/src/jcli/file/project.ts
@@ -1,10 +1,6 @@
 import { api, DBClass } from "@/api/mod.ts";
 
-import { MigrationFileEntry } from "./migrations-man.ts";
-import { FunctionFileEntry } from "./functions-man.ts";
 import { digest as doDigest } from "@/jcli/crypto.ts";
-
-import { join } from "path";
 
 const encoder = new TextEncoder();
 
@@ -16,21 +12,12 @@ function composeDigests(digests: ReadonlyArray<string>): Promise<string> {
   return digest(digests.toSorted().join(""));
 }
 
-async function digestMigrations(db: DBClass): Promise<string> {
-  const entries = db.queryEntries<{ path: string; hash: string }>(
+function digestMigrations(db: DBClass): Promise<string> {
+  const entries = db.queryEntries<{ hash: string }>(
     "SELECT path, hash FROM objects WHERE filetype = 'MIGRATION'",
   );
 
-  const digests: Array<string> = [];
-
-  for (const e of entries) {
-    const entry = new MigrationFileEntry(e.path);
-    const content = await entry.content();
-
-    digests.push(await digest(`${entry.version}${entry.name}${content}`));
-  }
-
-  return composeDigests(digests);
+  return composeDigests(entries.map((e) => e.hash));
 }
 
 async function digestFunctions(db: DBClass): Promise<string> {
@@ -41,18 +28,13 @@ async function digestFunctions(db: DBClass): Promise<string> {
   const functionFileHashes = new Map<string, Array<string>>();
 
   for (const e of entries) {
-    const [, functionName, ...relativePath] = e.path.split("/");
-    const FileEntryConstructor = FunctionFileEntry(functionName);
+    const [, functionName] = e.path.split("/");
 
     if (!functionFileHashes.has(functionName)) {
       functionFileHashes.set(functionName, []);
     }
 
-    const entry = new FileEntryConstructor(join(...relativePath));
-
-    functionFileHashes.get(functionName)!.push(
-      await digestFunctionFile(relativePath, await entry.content()),
-    );
+    functionFileHashes.get(functionName)!.push(e.hash);
   }
 
   const functionHashes: Array<string> = [];
@@ -62,13 +44,6 @@ async function digestFunctions(db: DBClass): Promise<string> {
   }
 
   return composeDigests(functionHashes);
-}
-
-function digestFunctionFile(
-  relativePath: ReadonlyArray<string>,
-  content: string,
-): Promise<string> {
-  return digest(`${join("/", ...relativePath)}${content}`);
 }
 
 function getConfiguration(db: DBClass): string {

--- a/src/jcli/project-builder.ts
+++ b/src/jcli/project-builder.ts
@@ -1,0 +1,153 @@
+import { api, PROJECT_DB_PATH } from "@/api/mod.ts";
+import { createMetadataQuery } from "@/api/db/queries/create-metadata.ts";
+import { createTableObjectsQuery } from "@/api/db/queries/create-table-objects.ts";
+import { createFunctionsQuery } from "@/api/db/queries/create-functions.ts";
+import { createConfigurationQuery } from "@/api/db/queries/create-configuration.ts";
+
+import { Config } from "@/jcli/config/config.ts";
+import {
+  ProjectDotJSON,
+  projectDotJSONPath,
+} from "@/jcli/config/project-json.ts";
+import { dirname, join } from "path";
+
+class ProjectBuilder {
+  constructor(public configuration: ProjectDotJSON) {}
+
+  async provisionFiles(): Promise<void> {
+    const projectName = this.configuration.name;
+
+    await api.fs.mkdir(projectName);
+    await api.fs.mkdir(join(projectName, "migrations"));
+    await api.fs.mkdir(join(projectName, "functions"));
+    await api.fs.mkdir(join(projectName, ".jcli"));
+
+    const projectDotJSON = new Config<ProjectDotJSON>(
+      projectDotJSONPath(projectName),
+    );
+
+    await projectDotJSON.set(this.configuration, { createNew: true });
+  }
+
+  provisionDatabases(): void {
+    const db = api.db.createDatabase(
+      `${this.configuration.name}/${PROJECT_DB_PATH}`,
+    );
+
+    db.execute(createMetadataQuery);
+    db.execute(createTableObjectsQuery);
+    db.execute(createFunctionsQuery);
+    db.execute(createConfigurationQuery);
+
+    db.query<never>("INSERT INTO configuration (data) VALUES (:data);", {
+      data: JSON.stringify(this.configuration.toJSON()),
+    });
+
+    db.close();
+  }
+
+  async buildMetadata(projectId: string) {
+    const db = await this.#connectDB();
+
+    db.query("INSERT INTO metadata (project_id) VALUES (:projectId)", {
+      projectId,
+    });
+
+    db.close();
+  }
+
+  async buildMigrations(
+    migrations: AsyncIterable<{
+      version: number;
+      name: string | null;
+      hash: string;
+      content: string;
+    }>,
+  ) {
+    const db = await this.#connectDB();
+
+    const createMigrationQuery = db.prepareQuery<
+      never,
+      never,
+      { path: string; hash: string }
+    >(
+      "INSERT INTO objects (path, hash, filetype) VALUES (:path, :hash, 'MIGRATION')",
+    );
+
+    for await (const { version, name, hash, content } of migrations) {
+      const path = name
+        ? join("migrations", `${version}_${name}.sql`)
+        : join("migrations", `${version}.sql`);
+
+      await api.fs.writeTextFile(join(this.configuration.name, path), content, {
+        createNew: true,
+      });
+
+      createMigrationQuery.execute({ path, hash });
+    }
+
+    createMigrationQuery.finalize();
+    db.close();
+  }
+
+  async buildFunctions(
+    functions: AsyncIterable<{
+      name: string;
+      files: ReadonlyArray<{
+        path: string;
+        hash: string;
+        code: string;
+      }>;
+    }>,
+  ) {
+    const db = await this.#connectDB();
+
+    const createFunctionQuery = db.prepareQuery<
+      never,
+      never,
+      { name: string }
+    >(
+      "INSERT INTO functions (name) VALUES (:name)",
+    );
+
+    const createFunctionFileQuery = db.prepareQuery<
+      never,
+      never,
+      { path: string; hash: string }
+    >(
+      "INSERT INTO objects (path, hash, filetype) VALUES (:path, :hash, 'FUNCTION')",
+    );
+
+    for await (const func of functions) {
+      createFunctionQuery.execute({ name: func.name });
+
+      for (const { path, hash, code } of func.files) {
+        const filePath = join("functions", func.name, path);
+
+        writeFunctionFile(join(this.configuration.name, filePath), code);
+
+        createFunctionFileQuery.execute({
+          path: filePath,
+          hash,
+        });
+      }
+    }
+
+    createFunctionQuery.finalize();
+    createFunctionFileQuery.finalize();
+    db.close();
+  }
+
+  async #connectDB() {
+    return await api.db.connect(
+      join(this.configuration.name, PROJECT_DB_PATH),
+    );
+  }
+}
+
+async function writeFunctionFile(path: string, code: string) {
+  await api.fs.mkdir(dirname(path), { recursive: true });
+  await api.fs.writeTextFile(path, code, { createNew: true });
+}
+
+export { ProjectBuilder };

--- a/src/subcommands/clone/action.ts
+++ b/src/subcommands/clone/action.ts
@@ -1,0 +1,17 @@
+import { GlobalOptions } from "@/args.ts";
+import { api } from "@/api/mod.ts";
+import { ProjectBuilder } from "@/jcli/project-builder.ts";
+
+export default async function action(
+  _options: GlobalOptions,
+  projectId: string,
+) {
+  const project = await api.jet.cloneProject({ projectId });
+  const builder = new ProjectBuilder(project.configuration);
+
+  await builder.provisionFiles();
+  builder.provisionDatabases();
+  builder.buildMetadata(projectId);
+  await builder.buildFunctions(project.functions);
+  await builder.buildMigrations(project.migrations);
+}

--- a/src/subcommands/clone/action.ts
+++ b/src/subcommands/clone/action.ts
@@ -5,9 +5,10 @@ import { ProjectBuilder } from "@/jcli/project-builder.ts";
 export default async function action(
   _options: GlobalOptions,
   projectId: string,
+  directory?: string,
 ) {
   const project = await api.jet.cloneProject({ projectId });
-  const builder = new ProjectBuilder(project.configuration);
+  const builder = new ProjectBuilder(project.configuration, { directory });
 
   await builder.provisionFiles();
   builder.provisionDatabases();

--- a/src/subcommands/clone/mod.ts
+++ b/src/subcommands/clone/mod.ts
@@ -1,0 +1,13 @@
+import { Command } from "cliffy";
+import errorHandler from "@/error-handler.ts";
+
+import { GlobalOptions } from "@/args.ts";
+import action from "./action.ts";
+
+const command = new Command<GlobalOptions>()
+  .description("Clone a Jet project.")
+  .arguments("<projectId>")
+  .error(errorHandler)
+  .action(action);
+
+export default command;

--- a/src/subcommands/clone/mod.ts
+++ b/src/subcommands/clone/mod.ts
@@ -6,7 +6,7 @@ import action from "./action.ts";
 
 const command = new Command<GlobalOptions>()
   .description("Clone a Jet project.")
-  .arguments("<projectId>")
+  .arguments("<projectId> [directory]")
   .error(errorHandler)
   .action(action);
 

--- a/src/subcommands/utilities.ts
+++ b/src/subcommands/utilities.ts
@@ -1,0 +1,8 @@
+import { api } from "@/api/mod.ts";
+
+export async function provisionProjectDirectories(projectName: string) {
+  await api.fs.mkdir(projectName);
+  await api.fs.mkdir(`${projectName}/migrations`);
+  await api.fs.mkdir(`${projectName}/functions`);
+  await api.fs.mkdir(`${projectName}/.jcli`);
+}

--- a/src/subcommands/utilities.ts
+++ b/src/subcommands/utilities.ts
@@ -1,8 +1,0 @@
-import { api } from "@/api/mod.ts";
-
-export async function provisionProjectDirectories(projectName: string) {
-  await api.fs.mkdir(projectName);
-  await api.fs.mkdir(`${projectName}/migrations`);
-  await api.fs.mkdir(`${projectName}/functions`);
-  await api.fs.mkdir(`${projectName}/.jcli`);
-}

--- a/test/api/db.ts
+++ b/test/api/db.ts
@@ -36,7 +36,7 @@ export function makeDB(): DBTest {
     createDatabase(path: string): DBClass {
       const db = new TestDB();
       db.countConnection();
-      databases.set(path, db);
+      databases.set(join(cwd, path), db);
 
       return db;
     },

--- a/test/api/fs.ts
+++ b/test/api/fs.ts
@@ -29,19 +29,25 @@ class Directory {
   ): Directory | undefined {
     if (undefined === name) return undefined;
 
-    if (0 === rest.length) return this.mkdir(name);
+    if (options.recursive) {
+      if (0 === rest.length) {
+        this.mkdir(name);
+        return this.#children.get(name) as Directory;
+      }
 
-    const child = this.#children.get(name);
-
-    if (!child && options.recursive) {
       this.mkdir(name);
       const dir = this.#children.get(name) as Directory;
-      return dir.mkdirRec(rest, options);
-    }
 
-    return child && (child instanceof Directory)
-      ? child.mkdirRec(rest, options)
-      : undefined;
+      return dir.mkdirRec(rest, options);
+    } else {
+      if (0 === rest.length) return this.mkdir(name);
+
+      const child = this.#children.get(name);
+
+      return child && (child instanceof Directory)
+        ? child.mkdirRec(rest, options)
+        : undefined;
+    }
   }
 
   mkdir(name: string): Directory | undefined {

--- a/test/subcommands/clone/action_test.ts
+++ b/test/subcommands/clone/action_test.ts
@@ -85,6 +85,17 @@ describe("clone", () => {
     assert(api.fs.hasDir("my_proj/.jcli"));
   });
 
+  it("creates project directory with specified directory", async () => {
+    assert(!api.fs.hasDir("specified"));
+
+    await action(options, projectId, "speicified");
+
+    assert(api.fs.hasDir("speicified"));
+    assert(api.fs.hasDir("speicified/migrations"));
+    assert(api.fs.hasDir("speicified/functions"));
+    assert(api.fs.hasDir("speicified/.jcli"));
+  });
+
   it("clones my_proj/project.json", async () => {
     await action(options, projectId);
 

--- a/test/subcommands/clone/action_test.ts
+++ b/test/subcommands/clone/action_test.ts
@@ -1,0 +1,272 @@
+import {
+  afterEach,
+  assert,
+  assertEquals,
+  assertObjectMatch,
+  beforeEach,
+  describe,
+  it,
+} from "@test/mod.ts";
+
+import { PROJECT_DB_PATH } from "@/api/mod.ts";
+
+import { setupAPI } from "@/api/mod.ts";
+
+import { APIClientTest, makeAPIClient } from "@test/api/mod.ts";
+
+import createProject from "@/subcommands/admin/projects/create/action.ts";
+import push from "@/subcommands/push/action.ts";
+import action from "@/subcommands/clone/action.ts";
+
+describe("clone", () => {
+  let api: APIClientTest;
+  let projectId: string;
+
+  const options = {};
+  const FUNC_PATH = "functions/my_func";
+
+  beforeEach(async () => {
+    api = makeAPIClient();
+    setupAPI(api);
+
+    await createProject({}, "my_proj");
+
+    projectId = api.jet.getProject({ projectName: "my_proj" })!.id;
+
+    api.chdir("my_proj");
+
+    ["a", "b", "c"].forEach((name, i) => {
+      api.fs.writeTextFile(
+        `migrations/20200000000${i}_${name}.sql`,
+        name,
+        {
+          createNew: true,
+        },
+      );
+    });
+
+    const writeFuncFile = async (path: string, content: string) => {
+      const fullPath = `${FUNC_PATH}/${path}`;
+
+      if (api.fs.hasFile(fullPath)) {
+        await api.fs.writeTextFile(fullPath, content);
+      } else {
+        await api.fs.writeTextFile(fullPath, content, {
+          createNew: true,
+        });
+      }
+    };
+
+    await api.fs.mkdir(FUNC_PATH);
+    await api.fs.mkdir(`${FUNC_PATH}/users`);
+    await api.fs.mkdir(`${FUNC_PATH}/posts`);
+    await writeFuncFile("index.ts", "index");
+    await writeFuncFile("users/mod.ts", "mod");
+    await writeFuncFile("posts/entry.ts", "entry");
+
+    await push({});
+
+    api.fs.mkdir(".tmp");
+    api.chdir(".tmp");
+  });
+
+  afterEach(() => {
+    api.cleanup();
+  });
+
+  it("creates project directories", async () => {
+    assert(!api.fs.hasDir("my_proj"));
+
+    await action(options, projectId);
+
+    assert(api.fs.hasDir("my_proj"));
+    assert(api.fs.hasDir("my_proj/migrations"));
+    assert(api.fs.hasDir("my_proj/functions"));
+    assert(api.fs.hasDir("my_proj/.jcli"));
+  });
+
+  it("clones my_proj/project.json", async () => {
+    await action(options, projectId);
+
+    const configuration = JSON.parse(
+      await api.fs.readTextFile("my_proj/project.json"),
+    ) as Record<"name" | "title" | "capabilities" | "instances", unknown>;
+
+    assertObjectMatch(configuration, {
+      name: "my_proj",
+      title: "my_proj",
+      capabilities: [],
+      instances: [],
+    });
+  });
+
+  it("provisions metadata.db", async () => {
+    await action(options, projectId);
+
+    const expectedDatabase = `my_proj/${PROJECT_DB_PATH}`;
+
+    assert(api.db.hasDatabase(expectedDatabase));
+
+    const database = await api.db.connect(expectedDatabase);
+
+    const columns = database.queryEntries<
+      { name: string; type: string; notnull: number; pk: number }
+    >(
+      `SELECT name, type, "notnull", pk FROM pragma_table_info(:tableName) ORDER BY name`,
+      { tableName: "metadata" },
+    );
+
+    assertEquals(columns.length, 1);
+
+    assertObjectMatch(columns[0], {
+      name: "project_id",
+      type: "TEXT",
+      notnull: 1,
+      pk: 0,
+    });
+
+    const metadata = database.query<[string]>(
+      "SELECT project_id FROM metadata",
+    );
+
+    assertEquals(metadata.length, 1);
+
+    const project = api.jet.getProject({
+      projectName: "my_proj",
+    })!;
+
+    assertEquals(metadata[0][0], project.id);
+
+    database.close();
+  });
+
+  it("provisions configuration.db", async () => {
+    await action(options, projectId);
+
+    const expectedDatabase = `my_proj/${PROJECT_DB_PATH}`;
+
+    assert(api.db.hasDatabase(expectedDatabase));
+
+    const database = await api.db.connect(expectedDatabase);
+
+    const columns = database.queryEntries<
+      { name: string; type: string; notnull: number; pk: number }
+    >(
+      `SELECT name, type, "notnull", pk FROM pragma_table_info(:tableName) ORDER BY name`,
+      { tableName: "configuration" },
+    );
+
+    assertEquals(columns.length, 1);
+
+    assertObjectMatch(columns[0], {
+      name: "data",
+      type: "TEXT",
+      notnull: 1,
+      pk: 0,
+    });
+
+    const data = database.query<[string]>("SELECT data FROM configuration");
+
+    assertEquals(data.length, 1);
+
+    assertObjectMatch(JSON.parse(data[0][0]), {
+      name: "my_proj",
+      title: "my_proj",
+      capabilities: [],
+      instances: [],
+    });
+
+    database.close();
+  });
+
+  it("clones migrations", async () => {
+    await action(options, projectId);
+
+    assert(api.fs.hasFile("my_proj/migrations/202000000000_a.sql"));
+    assertEquals(
+      await api.fs.readTextFile("my_proj/migrations/202000000000_a.sql"),
+      "a",
+    );
+    assert(api.fs.hasFile("my_proj/migrations/202000000001_b.sql"));
+    assertEquals(
+      await api.fs.readTextFile("my_proj/migrations/202000000001_b.sql"),
+      "b",
+    );
+    assert(api.fs.hasFile("my_proj/migrations/202000000002_c.sql"));
+    assertEquals(
+      await api.fs.readTextFile("my_proj/migrations/202000000002_c.sql"),
+      "c",
+    );
+
+    const expectedDatabase = `my_proj/${PROJECT_DB_PATH}`;
+
+    assert(api.db.hasDatabase(expectedDatabase));
+
+    const db = await api.db.connect(expectedDatabase);
+
+    const entries = db.queryEntries<{ path: string; hash: string }>(
+      "SELECT path, hash FROM objects WHERE filetype = 'MIGRATION' ORDER BY path",
+    );
+
+    assertEquals(entries.length, 3);
+    assertEquals(entries[0].path, "migrations/202000000000_a.sql");
+    assertEquals(entries[0].hash, "202000000000");
+    assertEquals(entries[1].path, "migrations/202000000001_b.sql");
+    assertEquals(entries[1].hash, "202000000001");
+    assertEquals(entries[2].path, "migrations/202000000002_c.sql");
+    assertEquals(entries[2].hash, "202000000002");
+
+    db.close();
+  });
+
+  it("clones functions", async () => {
+    await action(options, projectId);
+
+    assert(api.fs.hasFile(`my_proj/${FUNC_PATH}/index.ts`));
+    assert(api.fs.hasFile(`my_proj/${FUNC_PATH}/posts/entry.ts`));
+    assert(api.fs.hasFile(`my_proj/${FUNC_PATH}/users/mod.ts`));
+
+    const expectedDatabase = `my_proj/${PROJECT_DB_PATH}`;
+
+    assert(api.db.hasDatabase(expectedDatabase));
+
+    const db = await api.db.connect(expectedDatabase);
+
+    const columns = db.queryEntries<
+      { name: string; type: string; notnull: number; pk: number }
+    >(
+      `SELECT name, type, "notnull", pk FROM pragma_table_info(:tableName) ORDER BY name`,
+      { tableName: "functions" },
+    );
+
+    assertEquals(columns.length, 1);
+
+    assertObjectMatch(columns[0], {
+      name: "name",
+      type: "TEXT",
+      notnull: 0,
+      pk: 1,
+    });
+
+    const funcEntries = db.queryEntries<{ name: string }>(
+      "SELECT name FROM functions",
+    );
+
+    assertEquals(funcEntries.length, 1);
+    assertObjectMatch(funcEntries[0], { name: "my_func" });
+
+    const fileEntries = db.queryEntries<{ path: string; hash: string }>(
+      "SELECT path, hash FROM objects WHERE filetype = 'FUNCTION' ORDER BY path",
+    );
+
+    assertEquals(fileEntries.length, 3);
+    assertEquals(fileEntries[0].path, `${FUNC_PATH}/index.ts`);
+    assertEquals(fileEntries[0].hash, "index.ts");
+    assertEquals(fileEntries[1].path, `${FUNC_PATH}/posts/entry.ts`);
+    assertEquals(fileEntries[1].hash, "posts/entry.ts");
+    assertEquals(fileEntries[2].path, `${FUNC_PATH}/users/mod.ts`);
+    assertEquals(fileEntries[2].hash, "users/mod.ts");
+
+    db.close();
+  });
+});

--- a/test/subcommands/push/action/push-functions_test.ts
+++ b/test/subcommands/push/action/push-functions_test.ts
@@ -152,11 +152,20 @@ describe("functions", () => {
 
         assertEquals(entries.length, 3);
         assertEquals(entries[0].path, `${FUNC_PATH}/index.ts`);
-        assertEquals(entries[0].hash, await digest(encoder.encode("index")));
+        assertEquals(
+          entries[0].hash,
+          await digest(encoder.encode("/index.tsindex")),
+        );
         assertEquals(entries[1].path, `${FUNC_PATH}/posts/entry.ts`);
-        assertEquals(entries[1].hash, await digest(encoder.encode("entry")));
+        assertEquals(
+          entries[1].hash,
+          await digest(encoder.encode("/posts/entry.tsentry")),
+        );
         assertEquals(entries[2].path, `${FUNC_PATH}/users/mod.ts`);
-        assertEquals(entries[2].hash, await digest(encoder.encode("mod")));
+        assertEquals(
+          entries[2].hash,
+          await digest(encoder.encode("/users/mod.tsmod")),
+        );
 
         db.close();
       });
@@ -211,11 +220,20 @@ describe("functions", () => {
 
         assertEquals(entries.length, 3);
         assertEquals(entries[0].path, `${FUNC_PATH}/index.ts`);
-        assertEquals(entries[0].hash, await digest(encoder.encode("xedni")));
+        assertEquals(
+          entries[0].hash,
+          await digest(encoder.encode("/index.tsxedni")),
+        );
         assertEquals(entries[1].path, `${FUNC_PATH}/posts/entry.ts`);
-        assertEquals(entries[1].hash, await digest(encoder.encode("yrtne")));
+        assertEquals(
+          entries[1].hash,
+          await digest(encoder.encode("/posts/entry.tsyrtne")),
+        );
         assertEquals(entries[2].path, `${FUNC_PATH}/users/mod.ts`);
-        assertEquals(entries[2].hash, await digest(encoder.encode("dom")));
+        assertEquals(
+          entries[2].hash,
+          await digest(encoder.encode("/users/mod.tsdom")),
+        );
 
         db.close();
       });

--- a/test/subcommands/push/action/push-migrations_test.ts
+++ b/test/subcommands/push/action/push-migrations_test.ts
@@ -69,11 +69,20 @@ describe("migrations", () => {
 
       assertEquals(entries.length, 3);
       assertEquals(entries[0].path, "migrations/202301010000_a.sql");
-      assertEquals(entries[0].hash, await digest(encoder.encode("0")));
+      assertEquals(
+        entries[0].hash,
+        await digest(encoder.encode("202301010000a0")),
+      );
       assertEquals(entries[1].path, "migrations/202301010001_b.sql");
-      assertEquals(entries[1].hash, await digest(encoder.encode("1")));
+      assertEquals(
+        entries[1].hash,
+        await digest(encoder.encode("202301010001b1")),
+      );
       assertEquals(entries[2].path, "migrations/202301010002_c.sql");
-      assertEquals(entries[2].hash, await digest(encoder.encode("2")));
+      assertEquals(
+        entries[2].hash,
+        await digest(encoder.encode("202301010002c2")),
+      );
 
       db.close();
     });
@@ -127,19 +136,19 @@ describe("migrations", () => {
       assertEquals(entries[0].path, "migrations/202301010000_a.sql");
       assertEquals(
         entries[0].hash,
-        await digest(new TextEncoder().encode("2")),
+        await digest(new TextEncoder().encode("202301010000a2")),
       );
 
       assertEquals(entries[1].path, "migrations/202301010001.sql");
       assertEquals(
         entries[1].hash,
-        await digest(new TextEncoder().encode("1")),
+        await digest(new TextEncoder().encode("2023010100011")),
       );
 
       assertEquals(entries[2].path, "migrations/202301010002_c.sql");
       assertEquals(
         entries[2].hash,
-        await digest(new TextEncoder().encode("2")),
+        await digest(new TextEncoder().encode("202301010002c2")),
       );
 
       db.close();


### PR DESCRIPTION
这个 PR 还改了一下 hash 的计算，以前的方法是只计算文件内容，但现在改成了按 commit 时的方法计算，具体是：
- 对于 migration：`digest(version ++ name ++ content)`
- 对于 function file：`digest(path ++ code)`

原因是：
之前的存储在 sqlite 中的 hash 只有在 diff files 的时候可以使用，在 commit 时就不能使用了，因为计算的方法不同；现在做 clone 从后端拿 migrations 和 function files 的时候是能拿到后端的 hash 的，而 jcli 对齐这个 hash 的计算方法（也是做 commit 时计算 hash 的方法），就可以直接使用这个 hash 值而不用再计算一次了