### PR TITLE
feat: support shell auto-completion

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,4 @@
-import { Command } from "cliffy";
+import { Command, CompletionsCommand } from "cliffy";
 
 import { getConfig } from "@/api/mod.ts";
 import { setupLogger } from "@/jcli/logger.ts";
@@ -34,4 +34,5 @@ await new Command()
   .command("commit", commitCommand)
   .command("deploy", deployCommand)
   .command("clone", cloneCommand)
+  .command("completions", new CompletionsCommand())
   .parse(Deno.args);


### PR DESCRIPTION
```markdown
$ jcli completions bash

Usage: jcli completions bash

Description:

  Generate shell completions for bash.

  To enable bash completions for this program add following line to your ~/.bashrc:

      source <(jcli completions bash)

Options:

  -h, --help                  - Show this help.
  -n, --name  <command-name>  - The name of the main command.
```
