### PR TITLE
Fix computation of configuration hash

### DIFF
--- a/src/jcli/file/project.ts
+++ b/src/jcli/file/project.ts
@@ -51,7 +51,9 @@ function getConfiguration(db: DBClass): string {
     "SELECT data FROM configuration",
   );
 
-  return configuration;
+  const { name, title, capabilities, instances } = JSON.parse(configuration);
+
+  return JSON.stringify({ name, title, capabilities, instances });
 }
 
 export async function digestProject(db: DBClass): Promise<string> {


### PR DESCRIPTION
之前的做法会把多余的字段例如 "$schema" 也一起送到后端，结果算出来的 configuration hash 就不正确